### PR TITLE
Clamp ssd1306 multi-write length

### DIFF
--- a/Core/Inc/ssd1306.h
+++ b/Core/Inc/ssd1306.h
@@ -246,7 +246,8 @@ void ssd1306_I2C_Write(uint8_t address, uint8_t reg, uint8_t data);
  * @param  address: 7 bit slave address, left aligned, bits 7:1 are used, LSB bit is not used
  * @param  reg: register to write to
  * @param  *data: pointer to data array to write it to slave
- * @param  count: how many bytes will be written
+ * @param  count: how many bytes will be written. This value is limited
+ *         to 255 bytes internally.
  * @retval None
  */
 void ssd1306_I2C_WriteMulti(uint8_t address, uint8_t reg, uint8_t *data, uint16_t count);

--- a/Core/Src/ssd1306.c
+++ b/Core/Src/ssd1306.c
@@ -568,14 +568,17 @@ extern I2C_HandleTypeDef hi2c1;
 			p--;
 	}
 
-	void ssd1306_I2C_WriteMulti(uint8_t address, uint8_t reg, uint8_t* data, uint16_t count) {
-		uint8_t dt[256];
-		dt[0] = reg;
-		uint8_t i;
-		for(i = 0; i < count; i++)
-		dt[i+1] = data[i];
-		HAL_I2C_Master_Transmit(SSD1306_I2C, address, dt, count+1, 10);
-	}
+void ssd1306_I2C_WriteMulti(uint8_t address, uint8_t reg, uint8_t* data, uint16_t count) {
+        uint8_t dt[256];
+        dt[0] = reg;
+        if (count > 255) {
+                count = 255;
+        }
+        uint8_t i;
+        for(i = 0; i < count; i++)
+        dt[i+1] = data[i];
+        HAL_I2C_Master_Transmit(SSD1306_I2C, address, dt, count+1, 10);
+}
 
 
 	void ssd1306_I2C_Write(uint8_t address, uint8_t reg, uint8_t data) {


### PR DESCRIPTION
## Summary
- cap the buffer length in `ssd1306_I2C_WriteMulti()` at 255 bytes
- document the new 255 byte limit in `ssd1306_I2C_WriteMulti` comment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f6b883cb8832cbf335a0e0187b0f4